### PR TITLE
Use the default travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,3 @@ language: julia
 julia:
   - release
   - 0.4
-
-script: 
-    - julia -e 'Pkg.init(); Pkg.clone("https://github.com/johnybx/PowerLaws.jl.git")' 
-    - julia -e 'Pkg.test("PowerLaws")' 


### PR DESCRIPTION
Travis already does a git clone, but of a pull request or branch rather than latest master like `Pkg.clone` will do.

Note that you don't really need to make new tags if the only thing you change is Travis-related, since that's not visible to users except via the github repository.
